### PR TITLE
Data streams rest api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "SDK",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "axios": "^1.6.8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
-  "name": "SDK",
+  "name": "your-package-name",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "your-package-name",
+      "version": "1.0.0",
+      "license": "ISC",
       "dependencies": {
         "axios": "^1.6.8"
       }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "axios": "^1.6.8"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,15 @@
 {
+  "name": "loaf-sdk",
+  "version": "1.0.0",
+  "description": "Description of your package",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
   "dependencies": {
     "axios": "^1.6.8"
-  }
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
 }

--- a/src/lib/loaf-node.js
+++ b/src/lib/loaf-node.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const { URL } = require("url");
-const { put, update, makeConfigs } = require("../utils/send");
+import { URL } from "url";
+import { put, update, makeConfigs } from "../utils/send.js";
 
 const DEFAULT_CONFIG = {
   test: false,
@@ -64,4 +64,4 @@ function init(gatewayUrl, developerConfig) {
   return loafInstance;
 }
 
-module.exports = { init };
+export default { init };

--- a/src/lib/loaf-node.js
+++ b/src/lib/loaf-node.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import { URL } from "url";
-import { put, update, makeConfigs } from "../utils/send.js";
+import { post, patch, makeConfigs } from "../utils/send.js";
 
 const DEFAULT_CONFIG = {
   test: false,
@@ -15,11 +15,7 @@ async function sendEvent(host, path, eventName, userId, eventAttributes) {
     eventAttributes,
   };
 
-  const response = await put(
-    "event",
-    eventData,
-    makeConfigs(host, path, "POST", eventData),
-  );
+  const response = await post("event", eventData, makeConfigs(host, path));
 
   return response;
 }
@@ -30,12 +26,7 @@ async function makeUser(host, path, userId, userAttributes) {
     userAttributes,
   };
 
-  const response = await put(
-    "user",
-    userData,
-    makeConfigs(host, path, userData),
-  );
-
+  const response = await post("user", userData, makeConfigs(host, path));
   return response;
 }
 
@@ -45,7 +36,7 @@ async function updateUser(host, path, userId, userAttributes) {
     userAttributes,
   };
 
-  const response = await update(userData, makeConfigs(host, path));
+  const response = await patch(userData, makeConfigs(host, path));
   return response;
 }
 

--- a/src/lib/loaf-node.js
+++ b/src/lib/loaf-node.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { URL } = require("url");
-const { httpsSend, makeConfigs } = require("../utils/send");
+const { put, update, makeConfigs } = require("../utils/send");
 
 const DEFAULT_CONFIG = {
   test: false,
@@ -15,7 +15,7 @@ async function sendEvent(host, path, eventName, userId, eventAttributes) {
     eventAttributes,
   };
 
-  const response = await httpsSend(
+  const response = await put(
     "event",
     eventData,
     makeConfigs(host, path, "POST", eventData),
@@ -26,15 +26,16 @@ async function sendEvent(host, path, eventName, userId, eventAttributes) {
 
 async function makeUser(host, path, userId, userAttributes) {
   const userData = {
-    userId: userId,
+    userId,
     userAttributes,
   };
 
-  const response = await httpsSend(
+  const response = await put(
     "user",
     userData,
-    makeConfigs(host, path, "POST", userData),
+    makeConfigs(host, path, userData),
   );
+
   return response;
 }
 
@@ -44,18 +45,11 @@ async function updateUser(host, path, userId, userAttributes) {
     userAttributes,
   };
 
-  const response = await httpsSend(
-    "user",
-    userData,
-    makeConfigs(host, path, "PATCH"),
-  );
-
+  const response = await update(userData, makeConfigs(host, path));
   return response;
 }
 
 function init(gatewayUrl, developerConfig) {
-  // TODO; error handling for if `gateway` is missing. `gateway` is required.
-
   const url = new URL(gatewayUrl);
   const host = url.hostname;
   const path = url.pathname;
@@ -66,7 +60,7 @@ function init(gatewayUrl, developerConfig) {
 
   loafInstance.sendEvent = sendEvent.bind(null, host, `${path}/events`);
   loafInstance.makeUser = makeUser.bind(null, host, `${path}/users`);
-  loafInstance.updateUser = updateUser.bind(null, host, `${path}/users`);
+  loafInstance.updateUser = updateUser.bind(null, host, `${path}/update_users`);
   return loafInstance;
 }
 

--- a/src/utils/get-shard-key.js
+++ b/src/utils/get-shard-key.js
@@ -1,0 +1,19 @@
+const os = require("os");
+
+function getHostIP() {
+  const networkInterfaces = os.networkInterfaces();
+  for (const interfaceName of Object.keys(networkInterfaces)) {
+    const interfaces = networkInterfaces[interfaceName];
+    for (const info of interfaces) {
+      if (
+        info.family === "IPv4" &&
+        !info.Internal &&
+        info.address !== "127.0.0.1"
+      ) {
+        return info.address;
+      }
+    }
+  }
+}
+
+module.exports = getHostIP;

--- a/src/utils/get-shard-key.js
+++ b/src/utils/get-shard-key.js
@@ -1,4 +1,4 @@
-const os = require("os");
+import os from "os";
 
 function getHostIP() {
   const networkInterfaces = os.networkInterfaces();
@@ -16,4 +16,4 @@ function getHostIP() {
   }
 }
 
-module.exports = getHostIP;
+export default getHostIP;

--- a/src/utils/get-timestamp.js
+++ b/src/utils/get-timestamp.js
@@ -1,0 +1,6 @@
+function getTimeStamp() {
+  const now = new Date().toISOString();
+  return now.replace("T", "").replace("Z", "");
+}
+
+module.exports = getTimeStamp;

--- a/src/utils/get-timestamp.js
+++ b/src/utils/get-timestamp.js
@@ -3,4 +3,4 @@ function getTimeStamp() {
   return now.replace("T", "").replace("Z", "");
 }
 
-module.exports = getTimeStamp;
+export default getTimeStamp;

--- a/src/utils/process-attributes.js
+++ b/src/utils/process-attributes.js
@@ -1,0 +1,12 @@
+function stringifyObject(obj) {
+  for (var key in obj) {
+    if (typeof obj[key] === "object") {
+      obj[key] = stringifyObject(obj[key]);
+    } else {
+      obj[key] = String(obj[key]);
+    }
+  }
+  return obj;
+}
+
+export default stringifyObject;

--- a/src/utils/process-attributes.js
+++ b/src/utils/process-attributes.js
@@ -1,12 +1,17 @@
 function stringifyObject(obj) {
-  for (var key in obj) {
-    if (typeof obj[key] === "object") {
-      obj[key] = stringifyObject(obj[key]);
+  const newObj = {};
+  for (const key in obj) {
+    if (
+      typeof obj[key] === "number" ||
+      typeof obj[key] === "boolean" ||
+      typeof obj[key] === "string"
+    ) {
+      newObj[key] = String(obj[key]);
     } else {
-      obj[key] = String(obj[key]);
+      return new Error("attribute value must string, number, or boolean");
     }
   }
-  return obj;
+  return newObj;
 }
 
 export default stringifyObject;

--- a/src/utils/process-event.js
+++ b/src/utils/process-event.js
@@ -1,0 +1,25 @@
+const getShardKey = require("./get-shard-key.js");
+const getTimeStamp = require("./get-timestamp.js");
+
+const processEvent = (event) => {
+  if (!event.eventName || !event.userId) {
+    return new Error(
+      "An 'eventName', and 'userId' must be provided must be provided",
+    );
+  }
+
+  return JSON.stringify({
+    StreamName: "loaf-event-kinesis-stream",
+    PartitionKey: getShardKey(),
+    Data: Buffer.from(
+      JSON.stringify({
+        event_name: event.eventName,
+        user_id: event.userId || "default_user",
+        event_attributes: event.eventAttributes || null,
+        event_created: getTimeStamp(),
+      }),
+    ).toString("base64"),
+  });
+};
+
+module.exports = processEvent;

--- a/src/utils/process-event.js
+++ b/src/utils/process-event.js
@@ -3,10 +3,8 @@ import getTimeStamp from "./get-timestamp.js";
 import stringifyObject from "./process-attributes.js";
 
 const processEvent = (event) => {
-  if (!event.eventName || !event.userId) {
-    return new Error(
-      "An 'eventName', and 'userId' must be provided must be provided",
-    );
+  if (!event.eventName) {
+    return new Error("An 'eventName' must be provided must be provided");
   }
 
   return JSON.stringify({

--- a/src/utils/process-event.js
+++ b/src/utils/process-event.js
@@ -1,5 +1,6 @@
-const getShardKey = require("./get-shard-key.js");
-const getTimeStamp = require("./get-timestamp.js");
+import getShardKey from "./get-shard-key.js";
+import getTimeStamp from "./get-timestamp.js";
+import stringifyObject from "./process-attributes.js";
 
 const processEvent = (event) => {
   if (!event.eventName || !event.userId) {
@@ -15,11 +16,11 @@ const processEvent = (event) => {
       JSON.stringify({
         event_name: event.eventName,
         user_id: event.userId || "default_user",
-        event_attributes: event.eventAttributes || null,
+        event_attributes: stringifyObject(event.eventAttributes) || null,
         event_created: getTimeStamp(),
       }),
     ).toString("base64"),
   });
 };
 
-module.exports = processEvent;
+export default processEvent;

--- a/src/utils/process-event.js
+++ b/src/utils/process-event.js
@@ -4,7 +4,7 @@ import stringifyObject from "./process-attributes.js";
 
 const processEvent = (event) => {
   if (!event.eventName) {
-    return new Error("An 'eventName' must be provided must be provided");
+    return new Error("An 'eventName' must be provided");
   }
 
   return JSON.stringify({

--- a/src/utils/process-user.js
+++ b/src/utils/process-user.js
@@ -1,5 +1,6 @@
-const getShardKey = require("./get-shard-key.js");
-const getTimeStamp = require("./get-timestamp.js");
+import getShardKey from "./get-shard-key.js";
+import getTimeStamp from "./get-timestamp.js";
+import stringifyObject from "./process-attributes.js";
 
 const processUser = (user) => {
   if (!user.userId) {
@@ -12,11 +13,11 @@ const processUser = (user) => {
     Data: Buffer.from(
       JSON.stringify({
         user_id: user.userId,
-        user_attributes: user.userAttributes || null,
+        user_attributes: stringifyObject(user.userAttributes) || null,
         user_created: getTimeStamp(),
       }),
     ).toString("base64"),
   });
 };
 
-module.exports = processUser;
+export default processUser;

--- a/src/utils/process-user.js
+++ b/src/utils/process-user.js
@@ -4,7 +4,7 @@ import stringifyObject from "./process-attributes.js";
 
 const processUser = (user) => {
   if (!user.userId) {
-    return new Error("A userId' must be provided must be provided");
+    return new Error("A 'userId' must be provided");
   }
 
   return JSON.stringify({

--- a/src/utils/process-user.js
+++ b/src/utils/process-user.js
@@ -1,0 +1,22 @@
+const getShardKey = require("./get-shard-key.js");
+const getTimeStamp = require("./get-timestamp.js");
+
+const processUser = (user) => {
+  if (!user.userId) {
+    return new Error("A userId' must be provided must be provided");
+  }
+
+  return JSON.stringify({
+    StreamName: "loaf-user-kinesis-stream",
+    PartitionKey: getShardKey(),
+    Data: Buffer.from(
+      JSON.stringify({
+        user_id: user.userId,
+        user_attributes: user.userAttributes || null,
+        user_created: getTimeStamp(),
+      }),
+    ).toString("base64"),
+  });
+};
+
+module.exports = processUser;

--- a/src/utils/send.js
+++ b/src/utils/send.js
@@ -1,9 +1,10 @@
 "use strict";
 
-const axios = require("axios");
-const processEvent = require("./process-event");
-const processUser = require("./process-user");
-const getTimeStamp = require("./get-timestamp");
+import axios from "axios";
+import processEvent from "./process-event.js";
+import processUser from "./process-user.js";
+import getTimeStamp from "./get-timestamp.js";
+import stringifyObject from "./process-attributes.js";
 
 async function put(category, data, requestConfigs) {
   try {
@@ -32,7 +33,7 @@ async function update(data, requestConfigs) {
   try {
     const formattedData = {
       user_id: data.userId,
-      user_attributes: data.userAttributes,
+      user_attributes: stringifyObject(data.userAttributes),
       user_created: getTimeStamp(),
     };
 
@@ -57,8 +58,4 @@ function makeConfigs(host, path) {
   return requestConfigs;
 }
 
-module.exports = {
-  put,
-  update,
-  makeConfigs,
-};
+export { put, update, makeConfigs };

--- a/src/utils/send.js
+++ b/src/utils/send.js
@@ -3,8 +3,9 @@
 const axios = require("axios");
 const processEvent = require("./process-event");
 const processUser = require("./process-user");
+const getTimeStamp = require("./get-timestamp");
 
-async function httpsSend(category, data, requestConfigs) {
+async function put(category, data, requestConfigs) {
   try {
     let formatted;
     if (category === "event") {
@@ -15,31 +16,49 @@ async function httpsSend(category, data, requestConfigs) {
       throw new Error("Invalid category specified");
     }
 
-    // TODO
-    // Currently, we are sending data that only kinesis can parse
-    // Lambda requires different format
-    const response = await post(
+    const response = await axios.post(
       `https://${requestConfigs.host}${requestConfigs.path}`,
       formatted,
     );
 
     return response.data;
   } catch (error) {
+    console.error(error);
     return error;
   }
 }
 
-function makeConfigs(host, path, method) {
+async function update(data, requestConfigs) {
+  try {
+    const formattedData = {
+      user_id: data.userId,
+      user_attributes: data.userAtttributes,
+      user_created: getTimeStamp(),
+    };
+
+    const response = await axios.post(
+      `https://${requestConfigs.host}${requestConfigs.path}`,
+      formattedData,
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    return error;
+  }
+}
+
+function makeConfigs(host, path) {
   const requestConfigs = {
     host,
     path,
-    method,
   };
 
   return requestConfigs;
 }
 
 module.exports = {
-  httpsSend,
+  put,
+  update,
   makeConfigs,
 };

--- a/src/utils/send.js
+++ b/src/utils/send.js
@@ -32,7 +32,7 @@ async function update(data, requestConfigs) {
   try {
     const formattedData = {
       user_id: data.userId,
-      user_attributes: data.userAtttributes,
+      user_attributes: data.userAttributes,
       user_created: getTimeStamp(),
     };
 

--- a/src/utils/send.js
+++ b/src/utils/send.js
@@ -38,7 +38,7 @@ async function update(data, requestConfigs) {
 
     const response = await axios.post(
       `https://${requestConfigs.host}${requestConfigs.path}`,
-      formattedData,
+      JSON.stringify(formattedData),
     );
 
     return response.data;

--- a/src/utils/send.js
+++ b/src/utils/send.js
@@ -14,7 +14,7 @@ async function post(category, data, requestConfigs) {
     } else if (category === "user") {
       formatted = processUser(data);
     } else {
-      throw new Error("Invalid category specified");
+      return new Error("Invalid category specified");
     }
 
     const response = await axios.post(

--- a/src/utils/send.js
+++ b/src/utils/send.js
@@ -6,7 +6,7 @@ import processUser from "./process-user.js";
 import getTimeStamp from "./get-timestamp.js";
 import stringifyObject from "./process-attributes.js";
 
-async function put(category, data, requestConfigs) {
+async function post(category, data, requestConfigs) {
   try {
     let formatted;
     if (category === "event") {
@@ -29,7 +29,7 @@ async function put(category, data, requestConfigs) {
   }
 }
 
-async function update(data, requestConfigs) {
+async function patch(data, requestConfigs) {
   try {
     const formattedData = {
       user_id: data.userId,
@@ -58,4 +58,4 @@ function makeConfigs(host, path) {
   return requestConfigs;
 }
 
-export { put, update, makeConfigs };
+export { post, patch, makeConfigs };


### PR DESCRIPTION
This update allows the SDK to send data to the api gateway, which forwards it to a kinesis data stream for delivery of new data. The biggest changes are the format of the request body, as it must have the required fields of kinesis data streams.

They are some additional small changes like changing CommonJS imports to ES module imports. This should not be merged until the infra is ready to support it, contained in this PR: https://github.com/data-loaf/CLI/pull/24 